### PR TITLE
Add support for connecting to Sauna with a non-default pin code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.4.3] - 2026-07-12
+
+### Fixed
+
+* **Connection rejected with a non-default PIN:** HELLO always sent the factory-default PIN (`"0000"`), so a sauna with a custom PIN set on its control panel would reject every connection attempt with no error, leaving entities stuck on `unknown`.
+
+### Added
+
+* **Configurable PIN:** set during initial setup (discovered or manual) or later via Options, instead of hardcoded to `"0000"`.
+* **PIN rejection now logged:** the controller's connect reply is parsed, so a rejected PIN now logs a clear error and is exposed as `pin_rejected` in diagnostics.
+
 ## [0.4.2] - 2026-02-06
 
 ### Fixed

--- a/custom_components/tylo_sauna/__init__.py
+++ b/custom_components/tylo_sauna/__init__.py
@@ -10,10 +10,12 @@ from .const import (
     CONF_GUID,
     CONF_HOST,
     CONF_NAME,
+    CONF_PIN,
     CONF_PORT,
     CONF_EXPERIMENTAL_AROMA,
     DOMAIN,
     DEFAULT_CONTROL_PORT,
+    DEFAULT_PIN,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,6 +55,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     name = cfg.get(CONF_NAME, "Tylo Sauna")
 
     guid = cfg.get(CONF_GUID)  # may exist for discovery-based setup
+    pin = str(cfg.get(CONF_PIN) or DEFAULT_PIN)
     experimental_aroma = bool(cfg.get(CONF_EXPERIMENTAL_AROMA, False))
     debug_recording = bool(cfg.get(CONF_DEBUG_RECORDING, False))
 
@@ -62,6 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         port=port,
         name=name,
         guid=guid,
+        pin=pin,
         experimental_aroma=experimental_aroma,
         debug_recording=debug_recording,
     )

--- a/custom_components/tylo_sauna/config_flow.py
+++ b/custom_components/tylo_sauna/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 
-from .const import CONF_DEBUG_RECORDING
+from .const import CONF_DEBUG_RECORDING, CONF_PIN, DEFAULT_PIN
 from .storage import EndpointStore
 
 _LOGGER = logging.getLogger(__name__)
@@ -288,21 +288,28 @@ class TyloSaunaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             default_name = sauna.name or f"Tylo Sauna {sauna.host}"
             if user_input is not None:
                 name = (user_input.get("name") or "").strip() or default_name
+                pin = str(user_input.get(CONF_PIN, DEFAULT_PIN)).strip() or DEFAULT_PIN
 
-                await self.async_set_unique_id(sauna.guid)
-                self._abort_if_unique_id_configured()
+                if not pin.isdigit():
+                    errors["base"] = "invalid_pin"
+                else:
+                    await self.async_set_unique_id(sauna.guid)
+                    self._abort_if_unique_id_configured()
 
-                data = {
-                    "host": sauna.host,
-                    "port": int(sauna.port),               # IMPORTANT
-                    "name": name,
-                    "guid": sauna.guid,
-                }
-                return self.async_create_entry(title=name, data=data)
+                    data = {
+                        "host": sauna.host,
+                        "port": int(sauna.port),               # IMPORTANT
+                        "name": name,
+                        "guid": sauna.guid,
+                        CONF_PIN: pin,
+                    }
+                    return self.async_create_entry(title=name, data=data)
 
             schema = vol.Schema(
                 {
                     vol.Optional("name", default=default_name): str,
+                    # PIN configured on the sauna's own control panel ("0000" if never changed).
+                    vol.Optional(CONF_PIN, default=DEFAULT_PIN): str,
                 }
             )
 
@@ -341,6 +348,8 @@ class TyloSaunaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required("host", default=hinted_host): str,
                 port_field: int,
                 vol.Optional("name", default=hinted_name): str,
+                # PIN configured on the sauna's own control panel ("0000" if never changed).
+                vol.Optional(CONF_PIN, default=DEFAULT_PIN): str,
             }
         )
 
@@ -358,6 +367,10 @@ class TyloSaunaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     return self.async_show_form(step_id="confirm", data_schema=schema, errors=errors)
 
                 name = (user_input.get("name") or f"Tylo Sauna {host}").strip() or f"Tylo Sauna {host}"
+                pin = str(user_input.get(CONF_PIN, DEFAULT_PIN)).strip() or DEFAULT_PIN
+                if not pin.isdigit():
+                    errors["base"] = "invalid_pin"
+                    return self.async_show_form(step_id="confirm", data_schema=schema, errors=errors)
 
                 discovered_matches = [
                     s for s in (self._discovered.values() if self._discovered else [])
@@ -372,6 +385,7 @@ class TyloSaunaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     "host": host,
                     "port": port,
                     "name": name,
+                    CONF_PIN: pin,
                 }
                 if matched_guid:
                     data["guid"] = matched_guid
@@ -391,28 +405,36 @@ class TyloSaunaOptionsFlowHandler(config_entries.OptionsFlow):
         self._entry = config_entry
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        errors: dict[str, str] = {}
         if user_input is not None:
             host = str(user_input["host"]).strip()
             name = str(user_input.get("name", "Tylo Sauna")).strip() or "Tylo Sauna"
+            pin = str(user_input.get(CONF_PIN, DEFAULT_PIN)).strip() or DEFAULT_PIN
             experimental_aroma = bool(user_input.get(EXPERIMENTAL_AROMA_KEY, False))
             debug_recording = bool(user_input.get(CONF_DEBUG_RECORDING, False))
 
-            # store in entry.options
-            return self.async_create_entry(
-                title="",
-                data={
-                    "host": host,
-                    "name": name,
-                    EXPERIMENTAL_AROMA_KEY: experimental_aroma,
-                    CONF_DEBUG_RECORDING: debug_recording,
-                },
-            )
+            if not pin.isdigit():
+                errors["base"] = "invalid_pin"
+            else:
+                # store in entry.options
+                return self.async_create_entry(
+                    title="",
+                    data={
+                        "host": host,
+                        "name": name,
+                        CONF_PIN: pin,
+                        EXPERIMENTAL_AROMA_KEY: experimental_aroma,
+                        CONF_DEBUG_RECORDING: debug_recording,
+                    },
+                )
 
         current = {**self._entry.data, **self._entry.options}
         schema = vol.Schema(
             {
                 vol.Required("host", default=current.get("host", "")): str,
                 vol.Optional("name", default=current.get("name", "Tylo Sauna")): str,
+                # PIN configured on the sauna's own control panel ("0000" if never changed).
+                vol.Optional(CONF_PIN, default=str(current.get(CONF_PIN, DEFAULT_PIN))): str,
                 # Экспериментальная опция для steam/aroma устройств (по умолчанию выключена).
                 vol.Optional(
                     EXPERIMENTAL_AROMA_KEY,
@@ -424,4 +446,4 @@ class TyloSaunaOptionsFlowHandler(config_entries.OptionsFlow):
                 ): bool,
             }
         )
-        return self.async_show_form(step_id="init", data_schema=schema)
+        return self.async_show_form(step_id="init", data_schema=schema, errors=errors)

--- a/custom_components/tylo_sauna/const.py
+++ b/custom_components/tylo_sauna/const.py
@@ -7,7 +7,11 @@ CONF_HOST = "host"
 CONF_PORT = "port"
 CONF_NAME = "name"
 CONF_GUID = "guid"
+CONF_PIN = "pin"
 CONF_RELAXED_TELEMETRY = "relaxed_telemetry"
+
+# Sauna's connection PIN, set on its own control panel. "0000" is the factory default.
+DEFAULT_PIN = "0000"
 
 # Экспериментальные функции (по умолчанию выключены).
 # Включать только для отладки конкретных установок (например, steam + aroma).

--- a/custom_components/tylo_sauna/controller.py
+++ b/custom_components/tylo_sauna/controller.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from .const import (
     DEFAULT_CONTROL_PORT,
+    DEFAULT_PIN,
     DOMAIN,
     KEEPALIVE_INTERVAL,
     ONLINE_TIMEOUT_S,
@@ -20,12 +21,12 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# HELLO / INIT packets reverse engineered from the official app
-HELLO_PAYLOAD = bytes.fromhex(
-    "c23e33081412043030303028542879286c28f601282028722865286d286f28"
-    "74286528202863286f286e28742872286f286c3a025001"
-)
 INIT_SHORT = bytes.fromhex("8241020802")
+
+# Connect_reply status codes
+CONNECT_REPLY_PREFIX = bytes.fromhex("827d")
+CONNECT_ACCEPTED = 10
+CONNECT_REJECTED_PIN = 20
 
 # Light commands
 LIGHT_OFF_PAYLOAD = bytes.fromhex("a24204080a1000")
@@ -435,12 +436,39 @@ def encode_fault_ack(fault: FaultEvent) -> bytes:
     return _pb_encode_bytes_field(FAULT_ACK_FIELD, bytes(body))
 
 
+# HELLO / Connect_request, built with the configured PIN (reverse engineered from the
+# official app; byte-identical to the old static payload when pin="0000").
+def _build_connect_request(pin: str) -> bytes:
+    body = bytearray()
+    body += _pb_encode_varint_field(1, 20)  # profile = PROFILE_SMART_PHONE_APP
+    body += _pb_encode_bytes_field(2, str(pin).encode("utf-8"))  # pin (digits)
+    for ch in "Tylö remote control":
+        body += _pb_encode_varint_field(5, ord(ch))  # application_description
+    body += _pb_encode_bytes_field(7, _pb_encode_varint_field(10, 1))  # external_unit_features.connect_reject_door_switch
+    return _pb_encode_bytes_field(1000, bytes(body))
+
+
+def parse_connect_reply_status(data: bytes) -> int | None:
+    """Parse Connect_reply.status (field 2000 -> field 1 varint) from a HELLO response."""
+    if not data.startswith(CONNECT_REPLY_PREFIX):
+        return None
+    ln, i = _decode_varint(data, len(CONNECT_REPLY_PREFIX))
+    if ln is None:
+        return None
+    for field_no, wt, value in _pb_iter_fields(data[i : i + int(ln)]):
+        if field_no == 1 and wt == 0:
+            return int(value)
+    return None
+
+
 def _looks_like_tylo_telemetry(data: bytes) -> bool:
     """
     Heuristic check to avoid accepting random UDP noise as telemetry.
     """
     # Allow known non-telemetry packets that we still want to accept
     if data.startswith(b"\xc2\x7f"):  # favorites snapshot (field 2040)
+        return True
+    if data.startswith(CONNECT_REPLY_PREFIX):  # connect reply (field 2000)
         return True
     if data.startswith(b"\xf2\x83\x01"):  # fault event (field 2110)
         return True
@@ -507,6 +535,7 @@ class SaunaController:
         host: str,
         port: int = 54377,
         guid: str | None = None,
+        pin: str = DEFAULT_PIN,
         experimental_aroma: bool = False,
         debug_recording: bool = False,
     ):
@@ -514,6 +543,8 @@ class SaunaController:
         self.name = name
         self.host = host
         self.port = port
+        self.pin = str(pin) if pin else DEFAULT_PIN
+        self._hello_payload = _build_connect_request(self.pin)
         # Configured port (from UI). Actual control port may be learned from src_port.
         self.configured_port = int(port)
         self.control_port = int(port)
@@ -560,6 +591,9 @@ class SaunaController:
         # Faults / safety events
         self.last_fault: FaultEvent | None = None
         self.door_fault_pending: bool = False
+
+        # Connection PIN rejected by the controller (CONNECT_REJECTED_PIN)
+        self.pin_rejected: bool = False
 
         # Standby mode
         self.current_mode: int | None = None  # MODE_OFF/MODE_HEAT/MODE_STANDBY
@@ -674,11 +708,11 @@ class SaunaController:
         if not (0 < p <= 65535):
             return
         # Reuse the same pattern as the initial sequence (small delays are intentional).
-        self._send(HELLO_PAYLOAD, "PORT_SWITCH_HELLO 1", port=p)
+        self._send(self._hello_payload, "PORT_SWITCH_HELLO 1", port=p)
         await asyncio.sleep(0.1)
-        self._send(HELLO_PAYLOAD, "PORT_SWITCH_HELLO 2", port=p)
+        self._send(self._hello_payload, "PORT_SWITCH_HELLO 2", port=p)
         await asyncio.sleep(0.1)
-        self._send(HELLO_PAYLOAD, "PORT_SWITCH_HELLO 3", port=p)
+        self._send(self._hello_payload, "PORT_SWITCH_HELLO 3", port=p)
         await asyncio.sleep(0.1)
         self._send(INIT_SHORT, "PORT_SWITCH_INIT", port=p)
 
@@ -695,11 +729,11 @@ class SaunaController:
         self._hass.create_task(self._async_init_sequence())
 
     async def _async_init_sequence(self) -> None:
-        self._send_probe(HELLO_PAYLOAD, "HELLO 1")
+        self._send_probe(self._hello_payload, "HELLO 1")
         await asyncio.sleep(0.1)
-        self._send_probe(HELLO_PAYLOAD, "HELLO 2")
+        self._send_probe(self._hello_payload, "HELLO 2")
         await asyncio.sleep(0.1)
-        self._send_probe(HELLO_PAYLOAD, "HELLO 3")
+        self._send_probe(self._hello_payload, "HELLO 3")
         await asyncio.sleep(0.1)
         self._send_probe(INIT_SHORT, "INIT_SHORT")
         await asyncio.sleep(0.1)
@@ -783,7 +817,7 @@ class SaunaController:
 
         for p in uniq:
             # Probe like the official app: HELLO then INIT.
-            self._send(HELLO_PAYLOAD, desc=f"OFFLINE_PROBE_HELLO (port {p})", port=p)
+            self._send(self._hello_payload, desc=f"OFFLINE_PROBE_HELLO (port {p})", port=p)
             self._send(INIT_SHORT, desc=f"OFFLINE_PROBE_INIT (port {p})", port=p)
 
     def start_keepalive(self) -> None:
@@ -947,6 +981,31 @@ class SaunaController:
         self.last_rx_monotonic = time.monotonic()
         self.last_rx_dt = dt_util.utcnow()
         self._debug_record("rx", addr, data)
+
+        # --- Connect reply (response to HELLO / Connect_request) ---
+        if data.startswith(CONNECT_REPLY_PREFIX):
+            status = parse_connect_reply_status(data)
+            if status == CONNECT_REJECTED_PIN:
+                if not self.pin_rejected:
+                    self.pin_rejected = True
+                    _LOGGER.error(
+                        "Tylo Sauna: controller %s rejected the connection PIN (status=%s). "
+                        "No telemetry will be received until the correct PIN is set in the "
+                        "integration options (Settings > Devices & Services > Tylo Sauna > Configure).",
+                        src_ip,
+                        status,
+                    )
+            elif status == CONNECT_ACCEPTED:
+                if self.pin_rejected:
+                    self.pin_rejected = False
+                    _LOGGER.info("Tylo Sauna: connection accepted by %s (PIN ok)", src_ip)
+            elif status is not None:
+                _LOGGER.warning(
+                    "Tylo Sauna: connection rejected by %s (Connect_reply status=%s)",
+                    src_ip,
+                    status,
+                )
+            return
 
         # --- Fault events (door cancel etc.) ---
         if data.startswith(b"\xf2\x83\x01") or b"\xf2\x83\x01" in data:

--- a/custom_components/tylo_sauna/diagnostics.py
+++ b/custom_components/tylo_sauna/diagnostics.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-REDACT_KEYS = {"host", "guid"}
+REDACT_KEYS = {"host", "guid", "pin"}
 
 
 def _redact(data: dict, keys: set[str] | None = None) -> dict:
@@ -65,6 +65,7 @@ async def async_get_config_entry_diagnostics(
         "telemetry_host": "**REDACTED**" if controller.telemetry_host else None,
         "online": controller.is_online(),
         # Faults
+        "pin_rejected": controller.pin_rejected,
         "door_fault_pending": controller.door_fault_pending,
         "last_fault": {
             "code": controller.last_fault.code,

--- a/custom_components/tylo_sauna/manifest.json
+++ b/custom_components/tylo_sauna/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/skyer/home-assistant-tylo-sauna/issues",
   "loggers": ["custom_components.tylo_sauna"],
   "requirements": [],
-  "version": "0.4.2"
+  "version": "0.4.3"
 }

--- a/custom_components/tylo_sauna/strings.json
+++ b/custom_components/tylo_sauna/strings.json
@@ -15,13 +15,15 @@
         "data": {
           "host": "Host / IP address",
           "port": "UDP port",
-          "name": "Name"
+          "name": "Name",
+          "pin": "PIN (set on the sauna's control panel, \"0000\" if never changed)"
         }
       }
     },
     "error": {
       "device_not_found": "Selected device is no longer available. Please try again.",
-      "invalid_host": "Please enter a valid IP address or hostname."
+      "invalid_host": "Please enter a valid IP address or hostname.",
+      "invalid_pin": "PIN must contain digits only."
     }
   },
   "options": {
@@ -32,10 +34,14 @@
         "data": {
           "host": "Host / IP address",
           "name": "Name",
+          "pin": "PIN (set on the sauna's control panel, \"0000\" if never changed)",
           "experimental_aroma": "Experimental: enable steam aroma controls (Eucalyptus test)",
           "debug_recording": "Debug recording (captures UDP traffic for troubleshooting)"
         }
       }
+    },
+    "error": {
+      "invalid_pin": "PIN must contain digits only."
     }
   }
 }

--- a/custom_components/tylo_sauna/translations/en.json
+++ b/custom_components/tylo_sauna/translations/en.json
@@ -15,14 +15,16 @@
         "data": {
           "host": "Host / IP address",
           "port": "UDP port",
-          "name": "Name"
+          "name": "Name",
+          "pin": "PIN (set on the sauna's control panel, \"0000\" if never changed)"
         }
       }
     },
     "error": {
       "device_not_found": "Selected device is no longer available. Please try again.",
       "invalid_host": "Please enter a valid IP address or hostname.",
-      "invalid_port": "Please enter a valid UDP port (1-65535)."
+      "invalid_port": "Please enter a valid UDP port (1-65535).",
+      "invalid_pin": "PIN must contain digits only."
     }
   },
   "options": {
@@ -33,10 +35,14 @@
         "data": {
           "host": "Host / IP address",
           "name": "Name",
+          "pin": "PIN (set on the sauna's control panel, \"0000\" if never changed)",
           "experimental_aroma": "Experimental: enable steam aroma controls (Eucalyptus test)",
           "debug_recording": "Debug recording (captures UDP traffic for troubleshooting)"
         }
       }
+    },
+    "error": {
+      "invalid_pin": "PIN must contain digits only."
     }
   }
 }


### PR DESCRIPTION
## Summary

Fixes #3 — climate entity stays unknown after successful handshake – no telemetry received (HELO controller)

**Root cause:** the HELLO/`Connect_request` handshake always sends the factory-default PIN (`"0000"`), hardcoded into a static payload. If a non-default PIN is set on the sauna's own control panel, the controller rejects every connection attempt with `CONNECT_REJECTED_PIN` — but the integration never parsed the reply status.

Confirmed via a diagnostics dump and packet capture: the PIN is field 2 of the HELLO message, and the reply's status field reads `20` (`CONNECT_REJECTED_PIN`) on every attempt with the default PIN, versus `10` (`CONNECT_ACCEPTED`) on a working session using the correct PIN.

## Changes

- **PIN is now configurable** — set during initial setup (discovered or manual) or later via Options, instead of hardcoded to `"0000"`.
- **HELLO payload built dynamically** from the configured PIN, using the module's existing protobuf encode helpers (verified byte-identical to the old static payload when the PIN is left at `"0000"`).
- **PIN rejection is now visible**: the controller's `Connect_reply` status is parsed. A rejected PIN logs an error and is exposed as `pin_rejected` in diagnostics.
- Version bumped to 0.4.3, changelog updated.

## Testing

- Verified `_build_connect_request("0000")` produces byte-identical output to the previous hardcoded `HELLO_PAYLOAD` constant.
- Verified `parse_connect_reply_status()` against real captured bytes: returns `20` for the rejected reply, `10` for the accepted reply, and `None` for telemetry/non-reply packets.
- Confirmed on real hardware: with the hardcoded `"0000"` PIN, the connection was rejected and entities stayed `unknown` indefinitely; with the correct PIN set via this PR's config flow, the connection is accepted and telemetry flows normally.